### PR TITLE
Add support for Tomb1Main 2.16

### DIFF
--- a/TRGE.Coord/Level/Impls/TR3LevelEditor.cs
+++ b/TRGE.Coord/Level/Impls/TR3LevelEditor.cs
@@ -137,15 +137,11 @@ namespace TRGE.Coord
             }
 
             // Fish cause the game to crash if levels are off-sequence due to hardcoded offsets.
-            // So we just move the fish to 0,0,0 and remove their triggers, unless TR3Main is being used.
-            if (_scriptEditor.Edition.IsCommunityPatch)
-            {
-                return;
-            }
+            // So we just remove their triggers.
 
             TR3Level level = ReadLevel(args.LevelFileBaseName);
 
-            List<TR3Entity> fishies = level.Entities.FindAll(e => IsTargetFish(e));
+            List<TR3Entity> fishies = level.Entities.FindAll(e => e.TypeID == TR3Type.Fish || e.TypeID == TR3Type.Piranhas_N);
             if (fishies.Count > 0)
             {
                 FDControl control = new FDControl();
@@ -154,20 +150,12 @@ namespace TRGE.Coord
                 foreach (TR3Entity fish in fishies)
                 {
                     FDUtilities.RemoveEntityTriggers(level, level.Entities.IndexOf(fish), control);
-
-                    fish.X = fish.Y = fish.Z = 0;
                 }
 
                 control.WriteToLevel(level);
             }
 
             WriteLevel(level, args.LevelFileBaseName);
-        }
-
-        private bool IsTargetFish(TR3Entity e)
-        {
-            return e.X != 0 && e.Y != 0 && e.Z != 0 &&
-                (e.TypeID == TR3Type.Fish || e.TypeID == TR3Type.Piranhas_N);
         }
 
         protected override int GetSaveTarget(int numLevels)

--- a/TRGE.Core/Level/TRLevelType.cs
+++ b/TRGE.Core/Level/TRLevelType.cs
@@ -6,6 +6,6 @@
         Gym,
         Normal,
         Cutscene,
-        Current
+        Current,
     }
 }

--- a/TRGE.Core/Script/Impls/TR1Script.cs
+++ b/TRGE.Core/Script/Impls/TR1Script.cs
@@ -23,8 +23,6 @@ namespace TRGE.Core
         public string MainMenuPicture { get; set; }
         public string SavegameFmtLegacy { get; set; }
         public string SavegameFmtBson { get; set; }
-        public bool EnableGameModes { get; set; }
-        public bool EnableSaveCrystals { get; set; }
         public double DemoDelay { get; set; }
         public double[] WaterColor { get; set; }
         public double DrawDistanceFade { get; set; }
@@ -112,6 +110,12 @@ namespace TRGE.Core
         public int CameraSpeed { get; set; }
         public bool EnableSwingCancel { get; set; }
         public bool EnableTr2Jumping { get; set; }
+        public bool EnableGameModes { get; set; }
+        public bool EnableSaveCrystals { get; set; }
+        public bool FixBearAi { get; set; }
+        public bool LoadCurrentMusic { get; set; }
+        public bool LoadMusicTriggers { get; set; }
+
         #endregion
 
         public JObject GameflowData { get; internal set; }
@@ -125,8 +129,6 @@ namespace TRGE.Core
             MainMenuPicture = ReadString(nameof(MainMenuPicture), GameflowData);
             SavegameFmtLegacy = ReadString(nameof(SavegameFmtLegacy), GameflowData);
             SavegameFmtBson = ReadString(nameof(SavegameFmtBson), GameflowData);
-            EnableGameModes = ReadBool(nameof(EnableGameModes), GameflowData);
-            EnableSaveCrystals = ReadBool(nameof(EnableSaveCrystals), GameflowData);
             DemoDelay = ReadDouble(nameof(DemoDelay), GameflowData);
             WaterColor = ReadArray<double>(nameof(WaterColor), GameflowData);
             DrawDistanceFade = ReadDouble(nameof(DrawDistanceFade), GameflowData);
@@ -365,6 +367,12 @@ namespace TRGE.Core
             CameraSpeed                 = ReadInt(nameof(CameraSpeed), ConfigData, 5);
             EnableSwingCancel           = ReadBool(nameof(EnableSwingCancel), ConfigData, true);
             EnableTr2Jumping            = ReadBool(nameof(EnableTr2Jumping), ConfigData, false);
+
+            EnableGameModes             = ReadBool(nameof(EnableGameModes), ConfigData, true);
+            EnableSaveCrystals          = ReadBool(nameof(EnableSaveCrystals), ConfigData, false);
+            LoadMusicTriggers           = ReadBool(nameof(LoadMusicTriggers), ConfigData, true);
+            LoadCurrentMusic            = ReadBool(nameof(LoadCurrentMusic), ConfigData, true);
+            FixBearAi                   = ReadBool(nameof(FixBearAi), ConfigData, true);
         }
 
         private string ReadString(string key, JObject data)
@@ -575,8 +583,6 @@ namespace TRGE.Core
             Write(nameof(MainMenuPicture), MainMenuPicture, data);
             Write(nameof(SavegameFmtLegacy), SavegameFmtLegacy, data);
             Write(nameof(SavegameFmtBson), SavegameFmtBson, data);
-            Write(nameof(EnableGameModes), EnableGameModes, data);
-            Write(nameof(EnableSaveCrystals), EnableSaveCrystals, data);
             Write(nameof(DemoDelay), DemoDelay, data);
             Write(nameof(WaterColor), WaterColor, data);
             Write(nameof(DrawDistanceFade), DrawDistanceFade, data);
@@ -665,6 +671,11 @@ namespace TRGE.Core
             Write(nameof(CameraSpeed), CameraSpeed, data);
             Write(nameof(EnableSwingCancel), EnableSwingCancel, data);
             Write(nameof(EnableTr2Jumping), EnableTr2Jumping, data);
+            Write(nameof(EnableGameModes), EnableGameModes, data);
+            Write(nameof(EnableSaveCrystals), EnableSaveCrystals, data);
+            Write(nameof(FixBearAi), FixBearAi, data);
+            Write(nameof(LoadCurrentMusic), LoadCurrentMusic, data);
+            Write(nameof(LoadMusicTriggers), LoadMusicTriggers, data);
 
             // The existing data will have been re-read at this stage (T1M stores runtime config
             // in the same file so this may well have changed between saves in TRGE). Re-scan this

--- a/TRGE.Core/Script/Impls/TR1ScriptEditor.cs
+++ b/TRGE.Core/Script/Impls/TR1ScriptEditor.cs
@@ -133,6 +133,9 @@ namespace TRGE.Core
             CameraSpeed = config.GetInt(nameof(CameraSpeed), 5);
             EnableSwingCancel = config.GetBool(nameof(EnableSwingCancel), true);
             EnableTr2Jumping = config.GetBool(nameof(EnableTr2Jumping), false);
+            FixBearAi = config.GetBool(nameof(FixBearAi), true);
+            LoadCurrentMusic = config.GetBool(nameof(LoadCurrentMusic), true);
+            LoadMusicTriggers = config.GetBool(nameof(LoadMusicTriggers), true);
         }
 
         protected override void SaveImpl()
@@ -236,6 +239,9 @@ namespace TRGE.Core
             _config[nameof(CameraSpeed)] = CameraSpeed;
             _config[nameof(EnableSwingCancel)] = EnableSwingCancel;
             _config[nameof(EnableTr2Jumping)] = EnableTr2Jumping;
+            _config[nameof(FixBearAi)] = FixBearAi;
+            _config[nameof(LoadCurrentMusic)] = LoadCurrentMusic;
+            _config[nameof(LoadMusicTriggers)] = LoadMusicTriggers;
 
             AbstractTRScript backupScript = LoadBackupScript();
             AbstractTRScript randoBaseScript = LoadRandomisationBaseScript(); // #42
@@ -890,6 +896,24 @@ namespace TRGE.Core
         {
             get => (Script as TR1Script).EnableTr2Jumping;
             set => (Script as TR1Script).EnableTr2Jumping = value;
+        }
+
+        public bool FixBearAi
+        {
+            get => (Script as TR1Script).FixBearAi;
+            set => (Script as TR1Script).FixBearAi = value;
+        }
+
+        public bool LoadCurrentMusic
+        {
+            get => (Script as TR1Script).LoadCurrentMusic;
+            set => (Script as TR1Script).LoadCurrentMusic = value;
+        }
+
+        public bool LoadMusicTriggers
+        {
+            get => (Script as TR1Script).LoadMusicTriggers;
+            set => (Script as TR1Script).LoadMusicTriggers = value;
         }
     }
 }

--- a/TRGE.Core/Version/TRPatchTester.cs
+++ b/TRGE.Core/Version/TRPatchTester.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Text.RegularExpressions;
 
 namespace TRGE.Core
 {
@@ -61,8 +62,18 @@ namespace TRGE.Core
         {
             try
             {
+                string version = versionInfo.ProductVersion;
+                if (version != null)
+                {
+                    Match m = new Regex(@"\d+\.").Match(version);
+                    if (m.Success)
+                    {
+                        version = version[m.Index..].Trim();
+                    }
+                }
+
                 int[] parts = new int[] { 0, 0, 0 };
-                string[] productParts = versionInfo.ProductVersion.Split('.');
+                string[] productParts = version.Split('.');
                 for (int i = 0; i < productParts.Length; i++)
                 {
                     int j = 0;


### PR DESCRIPTION
Adds support for the T1M 2.16 gameflow changes, and additional new settings.
Also ensures fish are completely disabled in TR3 if sequencing is not the standard, as they can still cause issues in some levels regardless of the exe.
Resolves #135.